### PR TITLE
Support PMHC MFA login

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ variables if they are set:
 ```
 PMHC_USERNAME
 PMHC_PASSWORD
+PMHC_TOTP_SECRET
 ```
 
 Otherwise, you will be prompted for credentials interactively.
@@ -60,6 +61,7 @@ follows:
 ``` ps1
 $env:PMHC_USERNAME='your_username_here'
 $env:PMHC_PASSWORD=python -c 'import getpass; print(getpass.getpass())'
+$env:PMHC_TOTP_SECRET=python -c 'import getpass; print(getpass.getpass("TOTP Secret: "))'
 ```
 
 In a Unix shell (Mac, Linux), you can do:
@@ -67,7 +69,16 @@ In a Unix shell (Mac, Linux), you can do:
 ``` bash
 export PMHC_USERNAME='your_username_here'
 read -rs PMHC_PASSWORD && export PMHC_PASSWORD
+read -rs PMHC_TOTP_SECRET && export PMHC_TOTP_SECRET
 ```
+
+NOTE: `PMHC_TOTP_SECRET` is the unchanging base32-encoded TOTP secret,
+not the time-based six-digit code. You can likely find this secret in
+the 'advanced' section of your TOTP app. It will be a long string of
+upper-case letters and digits. The six-digit code will be automatically
+calculated based on the current time as required if `PMHC_TOTP_SECRET`
+is specified. Otherwise, the user will be prompted to enter the current
+six-digit code.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,25 @@ read -rs PMHC_TOTP_SECRET && export PMHC_TOTP_SECRET
 NOTE: `PMHC_TOTP_SECRET` is the unchanging base32-encoded TOTP secret,
 not the time-based six-digit code. You can likely find this secret in
 the 'advanced' section of your TOTP app. It will be a long string of
-upper-case letters and digits. The six-digit code will be automatically
-calculated based on the current time as required if `PMHC_TOTP_SECRET`
-is specified. Otherwise, the user will be prompted to enter the current
-six-digit code.
+upper-case letters and digits. See below for a list of TOTP apps which
+support viewing the TOTP secret. It is also possible to get the secret
+by scanning the setup QR code, or by clicking the button on the website
+to manually configure the TOTP app. The six-digit code will be
+automatically calculated based on the current time as required if
+`PMHC_TOTP_SECRET` is specified. Otherwise, the user will be prompted to
+enter the current six-digit code.
+
+Not all TOTP apps support viewing the secret. The following are known
+to support this:
+
+- [Aegis Authenticator](https://getaegis.app/) (Android only)
+- [Bitwarden
+  Authenticator](https://bitwarden.com/products/authenticator/)
+- [Ente Auth](https://github.com/ente-io/ente/tree/main/auth#readme)
+- [2FA Authenticator (2FAS)](https://2fas.com/)
+
+For more details, see the [list of recommended authenticator
+apps][mfa-apps] on our Data Wiki.
 
 ## Documentation
 
@@ -117,3 +132,4 @@ The generated documentation can be viewed at `docs/_build/html/index.html`.
 [Playwright]: https://playwright.dev/python/
 [Sphinx]: https://www.sphinx-doc.org/
 [docs]: https://swsphn.github.io/pmhclib/
+[mfa-apps]: https://datawiki.swsphn.com.au/software/gui-tools/multi-factor-authentication-apps/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pmhclib"
-version = "0.6.2"
+version = "0.7.0"
 description = "Python wrapper for unofficial PMHC MDS portal API"
 authors = [
     "David Wales <david.wales@swsphn.com.au>",
@@ -12,6 +12,7 @@ readme = "README.md"
 python = "^3.8"
 rich = "^13.7.0"
 playwright = "^1.40.0"
+pyotp = "^2.9.0"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "^7.0.0"


### PR DESCRIPTION
To test, ensure that you have logged into PMHC at least once, and setup a TOTP (Google Authenticator or similar) MFA code.

Start an interactive Python prompt with Poetry:

``` python
poetry run python
```

Then run the following test code:

``` python
from pmhclib import PMHC
with PMHC('PHN105', headless=False) as pmhc:
    pmhc.login()
    pmhc.download_pmhc_mds()
```

This will prompt you to enter your credentials and 6-digit MFA code.

To test the environment variable support, first set the following environment variables as described [here](https://github.com/swsphn/pmhclib/blob/1e10b7f332f189e80319012080ee6cf8c84fc2f0/README.md#usage), then run the above test code again.

Note that the `PMHC_TOTP_SECRET` environment variable is not the time-dependent six-digit code, but rather the long unchanging base32-encoded TOTP secret, which you might find in the 'advanced' section when editing your TOTP record.