### PR TITLE
Update PMHCSpecification with current options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pmhclib"
-version = "0.7.3"
+version = "0.8.0"
 description = "Python wrapper for unofficial PMHC MDS portal API"
 authors = [
     "David Wales <david.wales@swsphn.com.au>",

--- a/src/pmhclib/pmhc.py
+++ b/src/pmhclib/pmhc.py
@@ -75,10 +75,10 @@ class PMHCSpecificationRepresentation:
 class PMHCSpecification(PMHCSpecificationRepresentation, Enum):
     """Enum of valid PMHC specifications"""
 
-    ALL = "meta", "META 4.0"
-    PMHC = "pmhc", "PMHC 4.0"
-    HEADSPACE = "headspace", "headspace 2.0"
-    WAYBACK = "wayback", "WAYBACK 3.0"
+    ALL = "meta", "Include data from all specifications"
+    HEADSPACE = "headspace", "headspace 4.1"
+    PMHC = "pmhc", "PMHC 5.0"
+    SURVEY = "survey", "SURVEY 1.0"
 
 
 class PMHC:
@@ -488,7 +488,7 @@ class PMHC:
                 organisation.
             specification: Specification for extract. (default:
                 `PMHCSpecification.PMHC`, which returns data from the
-                PMHC 4.0 specification.)
+                current PMHC specification.)
             without_associated_dates: Enable extract option
                 "Include data without associated dates"
             matched_episodes: Enable extract option


### PR DESCRIPTION
The specification options are derived from the drop-down selector in the PMHC data extract page. They have been updated recently to support PMHC MDS version 5.0, so we need to update them here.

Fixes #4